### PR TITLE
Example: Rename PluginInterface -> Plugin

### DIFF
--- a/docs/plugin_system.rst
+++ b/docs/plugin_system.rst
@@ -81,10 +81,10 @@ The `plugin.py` file could contain something like the following:
 
 .. code-block:: python
     
-    from tmuxp.plugin import TmuxpPluginInterface
+    from tmuxp.plugin import TmuxpPlugin
     import datetime
 
-    class MyTmuxpPlugin(TmuxpPluginInterface):
+    class MyTmuxpPlugin(TmuxpPlugin):
         def __init__(self):
             """
             Initialize my custom plugin.
@@ -95,7 +95,7 @@ The `plugin.py` file could contain something like the following:
                 'tmuxp_min_version' = '1.6.2'
             }
 
-            TmuxpPluginInterface.__init__(
+            TmuxpPlugin.__init__(
                 self,
                 plugin_name='tmuxp-plugin-my-tmuxp-plugin',
                 **config
@@ -123,8 +123,8 @@ in a configuration file like the following:
 Plugin API
 ----------
 
-.. automethod:: tmuxp.plugin.TmuxpPluginInterface.before_workspace_builder
-.. automethod:: tmuxp.plugin.TmuxpPluginInterface.on_window_create
-.. automethod:: tmuxp.plugin.TmuxpPluginInterface.after_window_finished
-.. automethod:: tmuxp.plugin.TmuxpPluginInterface.before_script
-.. automethod:: tmuxp.plugin.TmuxpPluginInterface.reattach
+.. automethod:: tmuxp.plugin.TmuxpPlugin.before_workspace_builder
+.. automethod:: tmuxp.plugin.TmuxpPlugin.on_window_create
+.. automethod:: tmuxp.plugin.TmuxpPlugin.after_window_finished
+.. automethod:: tmuxp.plugin.TmuxpPlugin.before_script
+.. automethod:: tmuxp.plugin.TmuxpPlugin.reattach

--- a/tests/fixtures/pluginsystem/partials/all_pass.py
+++ b/tests/fixtures/pluginsystem/partials/all_pass.py
@@ -1,7 +1,7 @@
-from .test_plugin_helpers import MyTestTmuxpPluginInterface
+from .test_plugin_helpers import MyTestTmuxpPlugin
 
 
-class AllVersionPassPlugin(MyTestTmuxpPluginInterface):
+class AllVersionPassPlugin(MyTestTmuxpPlugin):
     def __init__(self):
         config = {
             'plugin_name': 'tmuxp-plugin-my-tmuxp-plugin',
@@ -17,4 +17,4 @@ class AllVersionPassPlugin(MyTestTmuxpPluginInterface):
             'tmux_version': '3.0',
             'tmuxp_version': '1.6.0',
         }
-        MyTestTmuxpPluginInterface.__init__(self, config)
+        MyTestTmuxpPlugin.__init__(self, config)

--- a/tests/fixtures/pluginsystem/partials/libtmux_version_fail.py
+++ b/tests/fixtures/pluginsystem/partials/libtmux_version_fail.py
@@ -1,31 +1,31 @@
-from .test_plugin_helpers import MyTestTmuxpPluginInterface
+from .test_plugin_helpers import MyTestTmuxpPlugin
 
 
-class LibtmuxVersionFailMinPlugin(MyTestTmuxpPluginInterface):
+class LibtmuxVersionFailMinPlugin(MyTestTmuxpPlugin):
     def __init__(self):
         config = {
             'plugin_name': 'libtmux-min-version-fail',
             'libtmux_min_version': '0.8.3',
             'libtmux_version': '0.7.0',
         }
-        MyTestTmuxpPluginInterface.__init__(self, config)
+        MyTestTmuxpPlugin.__init__(self, config)
 
 
-class LibtmuxVersionFailMaxPlugin(MyTestTmuxpPluginInterface):
+class LibtmuxVersionFailMaxPlugin(MyTestTmuxpPlugin):
     def __init__(self):
         config = {
             'plugin_name': 'libtmux-max-version-fail',
             'libtmux_max_version': '3.0',
             'libtmux_version': '3.5',
         }
-        MyTestTmuxpPluginInterface.__init__(self, config)
+        MyTestTmuxpPlugin.__init__(self, config)
 
 
-class LibtmuxVersionFailIncompatiblePlugin(MyTestTmuxpPluginInterface):
+class LibtmuxVersionFailIncompatiblePlugin(MyTestTmuxpPlugin):
     def __init__(self):
         config = {
             'plugin_name': 'libtmux-incompatible-version-fail',
             'libtmux_version_incompatible': ['0.7.1'],
             'libtmux_version': '0.7.1',
         }
-        MyTestTmuxpPluginInterface.__init__(self, config)
+        MyTestTmuxpPlugin.__init__(self, config)

--- a/tests/fixtures/pluginsystem/partials/test_plugin_helpers.py
+++ b/tests/fixtures/pluginsystem/partials/test_plugin_helpers.py
@@ -1,13 +1,13 @@
-from tmuxp.plugin import TmuxpPluginInterface
+from tmuxp.plugin import TmuxpPlugin
 
 
-class MyTestTmuxpPluginInterface(TmuxpPluginInterface):
+class MyTestTmuxpPlugin(TmuxpPlugin):
     def __init__(self, config):
         tmux_version = config.pop('tmux_version', None)
         libtmux_version = config.pop('libtmux_version', None)
         tmuxp_version = config.pop('tmuxp_version', None)
 
-        TmuxpPluginInterface.__init__(self, **config)
+        TmuxpPlugin.__init__(self, **config)
 
         # WARNING! This should not be done in anything but a test
         if tmux_version:

--- a/tests/fixtures/pluginsystem/partials/tmux_version_fail.py
+++ b/tests/fixtures/pluginsystem/partials/tmux_version_fail.py
@@ -1,27 +1,27 @@
-from .test_plugin_helpers import MyTestTmuxpPluginInterface
+from .test_plugin_helpers import MyTestTmuxpPlugin
 
 
-class TmuxVersionFailMinPlugin(MyTestTmuxpPluginInterface):
+class TmuxVersionFailMinPlugin(MyTestTmuxpPlugin):
     def __init__(self):
         config = {
             'plugin_name': 'tmux-min-version-fail',
             'tmux_min_version': '1.8',
             'tmux_version': '1.7',
         }
-        MyTestTmuxpPluginInterface.__init__(self, config)
+        MyTestTmuxpPlugin.__init__(self, config)
 
 
-class TmuxVersionFailMaxPlugin(MyTestTmuxpPluginInterface):
+class TmuxVersionFailMaxPlugin(MyTestTmuxpPlugin):
     def __init__(self):
         config = {
             'plugin_name': 'tmux-max-version-fail',
             'tmux_max_version': '3.0',
             'tmux_version': '3.5',
         }
-        MyTestTmuxpPluginInterface.__init__(self, config)
+        MyTestTmuxpPlugin.__init__(self, config)
 
 
-class TmuxVersionFailIncompatiblePlugin(MyTestTmuxpPluginInterface):
+class TmuxVersionFailIncompatiblePlugin(MyTestTmuxpPlugin):
     def __init__(self):
         config = {
             'plugin_name': 'tmux-incompatible-version-fail',
@@ -29,4 +29,4 @@ class TmuxVersionFailIncompatiblePlugin(MyTestTmuxpPluginInterface):
             'tmux_version': '2.3',
         }
 
-        MyTestTmuxpPluginInterface.__init__(self, config)
+        MyTestTmuxpPlugin.__init__(self, config)

--- a/tests/fixtures/pluginsystem/partials/tmuxp_version_fail.py
+++ b/tests/fixtures/pluginsystem/partials/tmuxp_version_fail.py
@@ -1,31 +1,31 @@
-from .test_plugin_helpers import MyTestTmuxpPluginInterface
+from .test_plugin_helpers import MyTestTmuxpPlugin
 
 
-class TmuxpVersionFailMinPlugin(MyTestTmuxpPluginInterface):
+class TmuxpVersionFailMinPlugin(MyTestTmuxpPlugin):
     def __init__(self):
         config = {
             'plugin_name': 'tmuxp-min-version-fail',
             'tmuxp_min_version': '1.6.0',
             'tmuxp_version': '1.5.6',
         }
-        MyTestTmuxpPluginInterface.__init__(self, config)
+        MyTestTmuxpPlugin.__init__(self, config)
 
 
-class TmuxpVersionFailMaxPlugin(MyTestTmuxpPluginInterface):
+class TmuxpVersionFailMaxPlugin(MyTestTmuxpPlugin):
     def __init__(self):
         config = {
             'plugin_name': 'tmuxp-max-version-fail',
             'tmuxp_max_version': '2.0.0',
             'tmuxp_version': '2.5',
         }
-        MyTestTmuxpPluginInterface.__init__(self, config)
+        MyTestTmuxpPlugin.__init__(self, config)
 
 
-class TmuxpVersionFailIncompatiblePlugin(MyTestTmuxpPluginInterface):
+class TmuxpVersionFailIncompatiblePlugin(MyTestTmuxpPlugin):
     def __init__(self):
         config = {
             'plugin_name': 'tmuxp-incompatible-version-fail',
             'tmuxp_version_incompatible': ['1.5.0'],
             'tmuxp_version': '1.5.0',
         }
-        MyTestTmuxpPluginInterface.__init__(self, config)
+        MyTestTmuxpPlugin.__init__(self, config)

--- a/tests/fixtures/pluginsystem/plugins/tmuxp_test_plugin_awf/tmuxp_test_plugin_awf/plugin.py
+++ b/tests/fixtures/pluginsystem/plugins/tmuxp_test_plugin_awf/tmuxp_test_plugin_awf/plugin.py
@@ -1,7 +1,7 @@
-from tmuxp.plugin import TmuxpPluginInterface
+from tmuxp.plugin import TmuxpPlugin
 
 
-class PluginAfterWindowFinished(TmuxpPluginInterface):
+class PluginAfterWindowFinished(TmuxpPlugin):
     def __init__(self):
         self.message = '[+] This is the Tmuxp Test Plugin'
 

--- a/tests/fixtures/pluginsystem/plugins/tmuxp_test_plugin_bs/tmuxp_test_plugin_bs/plugin.py
+++ b/tests/fixtures/pluginsystem/plugins/tmuxp_test_plugin_bs/tmuxp_test_plugin_bs/plugin.py
@@ -1,7 +1,7 @@
-from tmuxp.plugin import TmuxpPluginInterface
+from tmuxp.plugin import TmuxpPlugin
 
 
-class PluginBeforeScript(TmuxpPluginInterface):
+class PluginBeforeScript(TmuxpPlugin):
     def __init__(self):
         self.message = '[+] This is the Tmuxp Test Plugin'
 

--- a/tests/fixtures/pluginsystem/plugins/tmuxp_test_plugin_bwb/tmuxp_test_plugin_bwb/plugin.py
+++ b/tests/fixtures/pluginsystem/plugins/tmuxp_test_plugin_bwb/tmuxp_test_plugin_bwb/plugin.py
@@ -1,7 +1,7 @@
-from tmuxp.plugin import TmuxpPluginInterface
+from tmuxp.plugin import TmuxpPlugin
 
 
-class PluginBeforeWorkspaceBuilder(TmuxpPluginInterface):
+class PluginBeforeWorkspaceBuilder(TmuxpPlugin):
     def __init__(self):
         self.message = '[+] This is the Tmuxp Test Plugin'
 

--- a/tests/fixtures/pluginsystem/plugins/tmuxp_test_plugin_fail/tmuxp_test_plugin_fail/plugin.py
+++ b/tests/fixtures/pluginsystem/plugins/tmuxp_test_plugin_fail/tmuxp_test_plugin_fail/plugin.py
@@ -1,10 +1,10 @@
-from tmuxp.plugin import TmuxpPluginInterface
+from tmuxp.plugin import TmuxpPlugin
 
 
-class PluginFailVersion(TmuxpPluginInterface):
+class PluginFailVersion(TmuxpPlugin):
     def __init__(self):
         config = {
             'plugin_name': 'tmuxp-plugin-fail-version',
             'tmuxp_max_version': '0.0.0',
         }
-        TmuxpPluginInterface.__init__(self, **config)
+        TmuxpPlugin.__init__(self, **config)

--- a/tests/fixtures/pluginsystem/plugins/tmuxp_test_plugin_owc/tmuxp_test_plugin_owc/plugin.py
+++ b/tests/fixtures/pluginsystem/plugins/tmuxp_test_plugin_owc/tmuxp_test_plugin_owc/plugin.py
@@ -1,7 +1,7 @@
-from tmuxp.plugin import TmuxpPluginInterface
+from tmuxp.plugin import TmuxpPlugin
 
 
-class PluginOnWindowCreate(TmuxpPluginInterface):
+class PluginOnWindowCreate(TmuxpPlugin):
     def __init__(self):
         self.message = '[+] This is the Tmuxp Test Plugin'
 

--- a/tests/fixtures/pluginsystem/plugins/tmuxp_test_plugin_r/tmuxp_test_plugin_r/plugin.py
+++ b/tests/fixtures/pluginsystem/plugins/tmuxp_test_plugin_r/tmuxp_test_plugin_r/plugin.py
@@ -1,7 +1,7 @@
-from tmuxp.plugin import TmuxpPluginInterface
+from tmuxp.plugin import TmuxpPlugin
 
 
-class PluginReattach(TmuxpPluginInterface):
+class PluginReattach(TmuxpPlugin):
     def __init__(self):
         self.message = '[+] This is the Tmuxp Test Plugin'
 

--- a/tmuxp/plugin.py
+++ b/tmuxp/plugin.py
@@ -1,5 +1,6 @@
-import libtmux
 from distutils.version import LooseVersion
+
+import libtmux
 from libtmux.common import get_version
 
 from .__about__ import __version__
@@ -24,10 +25,10 @@ TMUXP_MIN_VERSION = '1.6.0'
 TMUXP_MAX_VERSION = None
 
 
-class TmuxpPluginInterface:
+class TmuxpPlugin:
     def __init__(
         self,
-        plugin_name='tmuxp-plugin-interface',
+        plugin_name='tmuxp-plugin',
         tmux_min_version=TMUX_MIN_VERSION,
         tmux_max_version=TMUX_MAX_VERSION,
         tmux_version_incompatible=None,
@@ -39,7 +40,7 @@ class TmuxpPluginInterface:
         tmuxp_version_incompatible=None,
     ):
         """
-        Initialize plugin interface.
+        Initialize plugin.
 
         The default version values are set to the versions that the plugin
         system requires.


### PR DESCRIPTION
@joseph-flinn This is the bikeshed I brought up in email

This is what renaming PluginInterface -> Plugin looks like

As far as convention/aesthetic in python, the term interface (while it's used here and there) is relatively rare.  Interfaces aren't typed enforced since it's duck typing ([`raise NotImplementedError`](https://docs.python.org/3/library/exceptions.html#NotImplementedError)) , so python interfaces are effectively partial interfaces and only bumped into at runtime.